### PR TITLE
Upkeep

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -74,7 +74,7 @@ charmcraft pack
 
 ```shell
 juju deploy ./karma-k8s.charm \
-  --resource karma-image=ghcr.io/prymitive/karma:v0.90
+  --resource karma-image=ghcr.io/prymitive/karma:v0.111
 ```
 
 ## Code overview

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Currently, supported relations are:
 
 ## OCI Images
 This charm can be used with the following image:
-- `ghcr.io/prymitive/karma:v0.90`
+- `ghcr.io/prymitive/karma:v0.111`
 
 
 [Karma source]: https://github.com/prymitive/karma

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -24,7 +24,7 @@ resources:
   karma-image:
     type: oci-image
     description: OCI image for karma
-    upstream-source: ghcr.io/prymitive/karma:v0.90
+    upstream-source: ghcr.io/prymitive/karma:v0.111
 
 requires:
   ingress:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,3 +63,4 @@ warn_unused_ignores = false
 [tool.pytest.ini_options]
 minversion = "6.0"
 log_cli_level = "INFO"
+asyncio_mode = "auto"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,12 +1,60 @@
+#!/usr/bin/env python3
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
+
+import functools
+import logging
+from collections import defaultdict
+from datetime import datetime
+from pathlib import Path
 
 import pytest
 from pytest_operator.plugin import OpsTest
 
+logger = logging.getLogger(__name__)
+
+
+class Store(defaultdict):
+    def __init__(self):
+        super(Store, self).__init__(Store)
+
+    def __getattr__(self, key):
+        """Override __getattr__ so dot syntax works on keys."""
+        try:
+            return self[key]
+        except KeyError:
+            raise AttributeError(key)
+
+    def __setattr__(self, key, value):
+        """Override __setattr__ so dot syntax works on keys."""
+        self[key] = value
+
+
+store = Store()
+
+
+def timed_memoizer(func):
+    @functools.wraps(func)
+    async def wrapper(*args, **kwargs):
+        fname = func.__qualname__
+        logger.info("Started: %s" % fname)
+        start_time = datetime.now()
+        if fname in store.keys():
+            ret = store[fname]
+        else:
+            logger.info("Return for {} not cached".format(fname))
+            ret = await func(*args, **kwargs)
+            store[fname] = ret
+        logger.info("Finished: {} in: {} seconds".format(fname, datetime.now() - start_time))
+        return ret
+
+    return wrapper
+
 
 @pytest.fixture(scope="module")
-async def charm_under_test(ops_test: OpsTest):
+@timed_memoizer
+async def charm_under_test(ops_test: OpsTest) -> Path:
     """Charm used for integration testing."""
-    charm = await ops_test.build_charm(".")
-    return charm
+    path_to_built_charm = await ops_test.build_charm(".")
+
+    return path_to_built_charm

--- a/tox.ini
+++ b/tox.ini
@@ -75,7 +75,7 @@ deps =
     integration: {[testenv:integration]deps}
 commands =
     charm: mypy {[vars]src_path} {posargs}
-    lib: mypy --python-version 3.5 {[vars]lib_path} {posargs}
+    lib: mypy --python-version 3.8 {[vars]lib_path} {posargs}
     unit: mypy {[vars]tst_path}/unit {posargs}
     integration: mypy {[vars]tst_path}/integration {posargs}
 
@@ -94,10 +94,8 @@ commands =
 [testenv:integration]
 description = Run integration tests
 deps =
-    #juju
-    git+https://github.com/juju/python-libjuju.git
+    juju
     pytest
-    #pytest-operator
-    git+https://github.com/charmed-kubernetes/pytest-operator.git
+    pytest-operator
 commands =
     pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/integration


### PR DESCRIPTION
## Issue
Make Karma linting use Python 3.8.

Add a memoizer.

Bump the GHCR tag (ghcr seems to be having an outage right now, but it's [otherwise present](https://github.com/prymitive/karma/pkgs/container/karma/57429870?tag=v0.111))

