### PR TITLE
use ruff instead of flake8

### DIFF
--- a/lib/charms/karma_k8s/v0/karma_dashboard.py
+++ b/lib/charms/karma_k8s/v0/karma_dashboard.py
@@ -328,7 +328,7 @@ class KarmaProvider(RelationManagerBase):
         # It is needed here because the target URL may be set by the consumer before any
         # "karma-dashboard" relation is joined, in which case there are no relation unit data bags
         # available for storing the target URL.
-        self._stored.set_default(config=dict())
+        self._stored.set_default(config={})
 
         events = self.charm.on[self.name]
         self.framework.observe(events.relation_joined, self._on_relation_joined)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,9 +27,6 @@ per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
 [tool.ruff.pydocstyle]
 convention = "google"
 
-[tool.ruff.mccabe]
-max-complexity = 10
-
 # Static analysis tools configuration
 [tool.mypy]
 pretty = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,26 +13,22 @@ show_missing = true
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
-max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
+[tool.ruff]
+line-length = 99
+exclude = ["__pycache__", "*.egg_info"]
+select = ["E", "W", "F", "C", "N", "R", "D", "I001"]
+# Ignore E501 because using black creates errors with this
 # Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
+ignore = ["E501", "D107", "N818", "RET504"]
 # D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103"]
-docstring-convention = "google"
-# Check for properly formatted copyright header in each file
-copyright-check = "True"
-copyright-author = "Canonical Ltd."
-copyright-regexp = "Copyright\\s\\d{4}([-,]\\d{4})*\\s+%(author)s"
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103"]}
+
+[tool.ruff.pydocstyle]
+convention = "google"
+
+[tool.ruff.mccabe]
+max-complexity = 10
 
 # Static analysis tools configuration
 [tool.mypy]

--- a/src/charm.py
+++ b/src/charm.py
@@ -10,14 +10,13 @@ import logging
 import yaml
 from charms.karma_k8s.v0.karma_dashboard import KarmaConsumer
 from charms.nginx_ingress_integrator.v0.ingress import IngressRequires
+from karma_client import Karma, KarmaBadResponse
+from kubernetes_service import K8sServicePatch, PatchFailed
 from ops.charm import CharmBase
 from ops.framework import StoredState
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, MaintenanceStatus
 from ops.pebble import Layer, PathError
-
-from karma_client import Karma, KarmaBadResponse
-from kubernetes_service import K8sServicePatch, PatchFailed
 
 logger = logging.getLogger(__name__)
 

--- a/src/kubernetes_service.py
+++ b/src/kubernetes_service.py
@@ -51,8 +51,7 @@ class K8sServicePatch:
                 raise PatchFailed(
                     "No permission to read cluster role. " "Run `juju trust` on this application."
                 ) from e
-            else:
-                raise e
+            raise e
 
     @staticmethod
     def _k8s_service(

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,11 +1,22 @@
 # Copyright 2021 Canonical Ltd.
 # See LICENSE file for licensing details.
 
+import grp
 import logging
 
 from pytest_operator.plugin import OpsTest
 
 log = logging.getLogger(__name__)
+
+
+def uk8s_group() -> str:
+    try:
+        # Classically confined microk8s
+        uk8s_group = grp.getgrnam("microk8s").gr_name
+    except KeyError:
+        # Strictly confined microk8s
+        uk8s_group = "snap_microk8s"
+    return uk8s_group
 
 
 async def get_unit_address(ops_test, app_name: str, unit_num: int) -> str:

--- a/tests/integration/test_kubectl_delete.py
+++ b/tests/integration/test_kubectl_delete.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 import yaml
-from helpers import get_config_values
+from helpers import get_config_values, uk8s_group
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +37,7 @@ async def test_config_values_are_retained_after_pod_deleted_and_restarted(ops_te
 
     cmd = [
         "sg",
-        "microk8s",
+        uk8s_group(),
         "-c",
         " ".join(["microk8s.kubectl", "delete", "pod", "-n", ops_test.model_name, pod_name]),
     ]

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,11 +5,10 @@ import shutil
 import tempfile
 import unittest
 
+from charm import KarmaCharm
 from charms.karma_k8s.v0.karma_dashboard import KarmaAlertmanagerConfig
 from ops.model import ActiveStatus
 from ops.testing import Harness
-
-from charm import KarmaCharm
 
 
 class TestKarmaAlertmanagerConfig(unittest.TestCase):

--- a/tests/unit/test_kubernetes_service.py
+++ b/tests/unit/test_kubernetes_service.py
@@ -6,7 +6,6 @@ import unittest
 from unittest.mock import patch
 
 import kubernetes
-
 from kubernetes_service import K8sServicePatch, PatchFailed
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -32,30 +32,21 @@ passenv =
 description = Apply coding style standards to code
 deps =
     black
-    isort
+    ruff
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
     black
+    ruff
     codespell
-    # Pinned until pyproject-flake8 supports flake8 >= 5
-    flake8 < 5
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
 commands =
     codespell {[vars]lib_path}
     codespell . --skip .git --skip .tox --skip build --skip lib --skip venv --skip .mypy_cache
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:static-{charm,lib,unit,integration}]


### PR DESCRIPTION
The **flake8** plugins we use are re-implemented in **ruff**, which is why they have been removed from the dependencies.

**isort** is enabled (and used when formatting) through the `I001` rule.

The "exclude list" has been updated to omit folders that **ruff** excludes by default.

Everything else is the same, the only difference being two new rules being ignored (which weren't checked before anyway): 
* `N818: Exception name should be named with an Error suffix`, which I excluded due to the big refactoring required for it;
* `RET504: Unnecessary variable assignment before return statement`, which we do everywhere as it increases readability.