### PR TITLE
Manually provide scheme to ingress

### DIFF
--- a/lib/charms/tls_certificates_interface/v2/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v2/tls_certificates.py
@@ -276,7 +276,6 @@ import copy
 import json
 import logging
 import uuid
-from collections import defaultdict
 from contextlib import suppress
 from datetime import datetime, timedelta
 from ipaddress import IPv4Address
@@ -309,7 +308,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 11
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1062,7 +1061,7 @@ class TLSCertificatesProvidesV2(Object):
 
     def get_issued_certificates(
         self, relation_id: Optional[int] = None
-    ) -> Dict[str, Dict[str, str]]:
+    ) -> Dict[str, List[Dict[str, str]]]:
         """Returns a dictionary of issued certificates.
 
         It returns certificates from all relations if relation_id is not specified.
@@ -1071,7 +1070,7 @@ class TLSCertificatesProvidesV2(Object):
         Returns:
             dict: Certificates per application name.
         """
-        certificates: Dict[str, Dict[str, str]] = defaultdict(dict)
+        certificates: Dict[str, List[Dict[str, str]]] = {}
         relations = (
             [
                 relation
@@ -1084,11 +1083,17 @@ class TLSCertificatesProvidesV2(Object):
         for relation in relations:
             provider_relation_data = _load_relation_data(relation.data[self.charm.app])
             provider_certificates = provider_relation_data.get("certificates", [])
+
+            certificates[relation.app.name] = []  # type: ignore[union-attr]
             for certificate in provider_certificates:
                 if not certificate.get("revoked", False):
-                    certificates[relation.app.name].update(  # type: ignore[union-attr]
-                        {certificate["certificate_signing_request"]: certificate["certificate"]}
+                    certificates[relation.app.name].append(  # type: ignore[union-attr]
+                        {
+                            "csr": certificate["certificate_signing_request"],
+                            "certificate": certificate["certificate"],
+                        }
                     )
+
         return certificates
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
@@ -1237,9 +1242,9 @@ class TLSCertificatesProvidesV2(Object):
             bool: True/False depending on whether a certificate has been issued for the given CSR.
         """
         issued_certificates_per_csr = self.get_issued_certificates()[app_name]
-        for request, cert in issued_certificates_per_csr.items():
-            if request == csr:
-                return csr_matches_certificate(csr, cert)
+        for issued_pair in issued_certificates_per_csr:
+            if "csr" in issued_pair and issued_pair["csr"] == csr:
+                return csr_matches_certificate(csr, issued_pair["certificate"])
         return False
 
 

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -623,11 +623,15 @@ class IngressPerAppRequirer(_IngressPerAppBase):
              requirer unit; if unspecified, FQDN will be used instead
             port: the port of the service (required)
         """
+        # This public method may be used at various points of the charm lifecycle, possible when
+        # the ingress relation is not yet there.
+        # Abort if there is no relation (instead of requiring the caller to guard against it).
+        if not self.relation:
+            return
+
         # get only the leader to publish the data since we only
         # require one unit to publish it -- it will not differ between units,
         # unlike in ingress-per-unit.
-        assert self.relation, "no relation"
-
         if self.unit.is_leader():
             app_databag = self.relation.data[self.app]
 

--- a/lib/charms/traefik_k8s/v2/ingress.py
+++ b/lib/charms/traefik_k8s/v2/ingress.py
@@ -79,7 +79,7 @@ LIBAPI = 2
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 PYDEPS = ["pydantic<2.0"]
 
@@ -612,10 +612,13 @@ class IngressPerAppRequirer(_IngressPerAppBase):
             host, port = self._auto_data
             self.provide_ingress_requirements(host=host, port=port)
 
-    def provide_ingress_requirements(self, *, host: Optional[str] = None, port: int):
+    def provide_ingress_requirements(
+        self, *, scheme: Optional[str] = None, host: Optional[str] = None, port: int
+    ):
         """Publishes the data that Traefik needs to provide ingress.
 
         Args:
+            scheme: Scheme to be used; if unspecified, use the one used by __init__.
             host: Hostname to be used by the ingress provider to address the
              requirer unit; if unspecified, FQDN will be used instead
             port: the port of the service (required)
@@ -627,11 +630,16 @@ class IngressPerAppRequirer(_IngressPerAppBase):
 
         if self.unit.is_leader():
             app_databag = self.relation.data[self.app]
+
+            if not scheme:
+                # If scheme was not provided, use the one given to the constructor.
+                scheme = self._get_scheme()
+
             try:
                 IngressRequirerAppData(  # type: ignore  # pyright does not like aliases
                     model=self.model.name,
                     name=self.app.name,
-                    scheme=self._get_scheme(),
+                    scheme=scheme,
                     port=port,
                     strip_prefix=self._strip_prefix,  # type: ignore  # pyright does not like aliases
                     redirect_https=self._redirect_https,  # type: ignore  # pyright does not like aliases

--- a/src/charm.py
+++ b/src/charm.py
@@ -12,6 +12,7 @@ import subprocess
 from pathlib import Path
 from time import sleep
 from typing import Optional
+from urllib.parse import urlparse
 
 import yaml
 from charms.catalogue_k8s.v0.catalogue import CatalogueConsumer, CatalogueItem
@@ -86,7 +87,8 @@ class KarmaCharm(CharmBase):
             port=self._port,
             scheme=lambda: "https" if self.server_cert.cert else "http",
             redirect_https=True,
-            strip_prefix=True,
+            # karma config options do not support reverse proxy with path stripping
+            strip_prefix=False,
         )
         self.framework.observe(self.ingress.on.ready, self._handle_ingress)  # pyright: ignore
         self.framework.observe(self.ingress.on.revoked, self._handle_ingress)  # pyright: ignore
@@ -204,9 +206,11 @@ class KarmaCharm(CharmBase):
             if self.server_cert.cert:
                 am["tls"] = {"ca": self.CA_CERT_PATH}
 
+        prefix = urlparse(self._external_url).path.strip("/")
         config = {
             "alertmanager": {"servers": alertmanagers},
             "listen": {
+                "prefix": f"/{prefix}/" if prefix else "/",
                 "port": self.port,
                 # The TLS section is allowed to have empty entries
                 # https://github.com/prymitive/karma/blob/main/docs/CONFIGURATION.md#listen

--- a/src/charm.py
+++ b/src/charm.py
@@ -158,6 +158,9 @@ class KarmaCharm(CharmBase):
         subprocess.run(["update-ca-certificates", "--fresh"])
 
     def _on_server_cert_changed(self, event=None):
+        self.ingress.provide_ingress_requirements(
+            scheme="https" if self.server_cert.cert else "http", port=self.port
+        )
         self._common_exit_hook()
 
     def _common_exit_hook(self) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -79,6 +79,9 @@ commands =
       -m pytest -v --tb native --log-cli-level=INFO -s {posargs} {[vars]tst_path}/unit
     coverage report
 
+[testenv:scenario]
+# Placeholder env so CI won't fail.
+
 [testenv:integration]
 description = Run integration tests
 deps =


### PR DESCRIPTION
## Issue
1. Karma ingress URL remains FQDN even after relating to Traefik.
2. Karma does not support reverse proxy with path stripping.


## Solution
1. Call an updater method to provide updated scheme.
2. Set `stripPrefix` to False.

Addresses #29.


## Testing Instructions
Relate `ca - trfk - (karma - ca) - catalogue`, and make sure the karma URL displayed in catalogue is the ingress URL and not the k8s fqdn.

In tandem with:
- https://github.com/canonical/traefik-k8s-operator/pull/233

## Release Notes
Manually provide scheme to ingress.
