### PR TITLE
Adjust references to _external_url

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -349,7 +349,7 @@ class KarmaCharm(CharmBase):
         self.container.restart(self._service_name)
 
         # Assuming FQDN is always part of the SANs DNS.
-        self.api = Karma(self._internal_url)
+        self.api = Karma(self._external_url)
         # The `/health` endpoint responds with "Pong" ~1 sec after restart
         for attempt in range(1, 4):
             if self.api.healthy:
@@ -367,7 +367,7 @@ class KarmaCharm(CharmBase):
         Logs list of peers, uptime and version info.
         """
         # Assuming FQDN is always part of the SANs DNS.
-        self.api = Karma(self._internal_url)
+        self.api = Karma(self._external_url)
 
         try:
             version = self.api.version


### PR DESCRIPTION
## Issue
Fixes charm going into `BlockedState` with message `Service restarted but karma server does not respond well on http://karma-k8s-0.karma-k8s-endpoints.cos.svc.cluster.local:8080` when related to traefik due to a couple of functions still pointing at `_internal_url`

## Solution
Update references to `_external_url` instead of `_internal_url`.

## Testing Instructions
1. juju deploy cos-lite & karma-k8s
2. juju relate karm-k8s to (traefik & catalogue & alertmanager)
3. verify that karma is in catalogue and accessible through external url
